### PR TITLE
Remove tabs permission

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -30,7 +30,6 @@
     "storage",
     "contextMenus",
     "notifications",
-    "tabs",
     "offscreen"
   ],
 

--- a/src/background/managers/completion-handler.ts
+++ b/src/background/managers/completion-handler.ts
@@ -143,20 +143,6 @@ export class CompletionHandler {
       console.log('[DEBUG][CompletionHandler] Closing completion tab:', { tabId: completionTabId });
       await chrome.tabs.remove(completionTabId);
     }
-
-    /*
-    const tabs = await chrome.tabs.query({ url: chrome.runtime.getURL('phaseComplete.html') });
-    console.log('[DEBUG][CompletionHandler] closeCompletionPages:', {
-      timestamp: new Date().toISOString(),
-      tabsFound: tabs.length,
-      tabIds: tabs.map(t => t.id)
-    });
-    
-    for (const tab of tabs) {
-      console.log('[DEBUG][CompletionHandler] Closing completion tab:', { tabId: tab.id });
-      await chrome.tabs.remove(tab.id!);
-    }
-    */
   }
 
   private async openCompletionPage(): Promise<void> {


### PR DESCRIPTION
The 'tabs' permission can be removed if we store the completion tab id at creation. This way we don't need to iterate (and read) through all tabs anymore to find it.

Without requiring the `tabs` permission users would not get the access request to `Read your browsing history` when installing the extension, making it less worrisome in terms of privacy.
